### PR TITLE
Created exception filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gpd_backend",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gpd_backend",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^10.0.0",

--- a/src/common/filters/custom-exception.filter.ts
+++ b/src/common/filters/custom-exception.filter.ts
@@ -1,0 +1,40 @@
+import { ArgumentsHost, BadRequestException, ExceptionFilter, HttpException, HttpStatus } from "@nestjs/common";
+import { ValidationError } from "class-validator";
+
+export class CustomExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const status = exception.getStatus();
+    const exceptionResponse = exception.getResponse();
+
+    const errorMessages = {
+      [HttpStatus.BAD_REQUEST]: 'Solicitud incorrecta',
+      [HttpStatus.UNAUTHORIZED]: 'No autorizado',
+      [HttpStatus.FORBIDDEN]: 'Prohibido',
+      [HttpStatus.NOT_FOUND]: 'Ruta no encontrada',
+      [HttpStatus.INTERNAL_SERVER_ERROR]: 'Error interno del servidor',
+      [HttpStatus.REQUEST_TIMEOUT]: 'Tiempo de espera agotado',
+      [HttpStatus.BAD_GATEWAY]: 'Ruta de acceso incorrecta',
+    }
+    const errorMessage: string = errorMessages[status] || 'Error desconocido';
+
+    let message: string = ''
+    if (exception instanceof BadRequestException && Array.isArray(exceptionResponse['message'])) {
+      message = exceptionResponse['message'].map((msg: string | ValidationError) => {
+        if (typeof msg === 'string') {
+          return msg
+        }
+        return Object.values(msg.constraints).join(', ')
+      }).join(', ')
+    } else if (typeof exceptionResponse === 'object') {
+      message = exceptionResponse['message'] || message
+    }
+
+    response.status(status).json({
+      message: message,
+      error: errorMessage,
+    })
+  }
+}

--- a/src/common/validation/custom-validation.pipe.ts
+++ b/src/common/validation/custom-validation.pipe.ts
@@ -1,0 +1,23 @@
+import { BadRequestException, Injectable, ValidationPipe } from "@nestjs/common";
+import { ValidationError, ValidatorOptions } from "class-validator";
+
+export interface ValidationPipeOptions extends ValidatorOptions {
+    transform?: boolean;
+    disableErrorMessages?: boolean;
+    exceptionFactory?: (errors: ValidationError[]) => any;
+}
+@Injectable()
+export class CustomValidationPipe extends ValidationPipe {
+    protected flattenValidationErrors(validationErrors: ValidationError[]): string[] {
+        const messages = validationErrors.map(error => {
+            return Object.values(error.constraints).join(', ')
+        })
+        return messages
+    }
+    createExceptionFactory() {
+        return (validationErrors: ValidationError[] = []) => {
+            const messages = this.flattenValidationErrors(validationErrors)
+            return new BadRequestException(messages.join(', '))
+        }
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { BigIntInterceptor } from './interceptors/bigint.interceptor';
+import { CustomExceptionFilter } from './common/filters/custom-exception.filter';
+import { CustomValidationPipe } from './common/validation/custom-validation.pipe';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalInterceptors(new BigIntInterceptor());
+  app.useGlobalPipes(new CustomValidationPipe());
+  app.useGlobalFilters(new CustomExceptionFilter())
   await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
## Overview
This pull request implements the functionalities for the `CustomExceptionFilter` and the `CustomValidationPipe` integrated at app level.

## Changes
- **Filter:** Added `CustomExceptionFilter` handles the filtering of the http exceptions such as Bad Request of  Unauthorized.
- **ValidationPipe:** Added `CustomValidationPipe` handles the messages when a validation error occurs.

## Details
1. **CustomExceptionFilter**
   - `errorMessages`: Error messages depending on the http status.
   - `message`: The validation error message.

2. **CustomValidationPipe**
   - `flattenValidationErrors()`: Map the validation error messages and join them into one single string.
   - `createExceptionFactory()`: Returns a BadRequestException with the validation error messages joined.

## Related Issues
if is related to an issue or can close an issue
- Closes #10 

## Notes
- To perform tests over this functionalities, you may need to use `class-validator` in your DTOs and send wrong data.

Thank you for reviewing this pull request. I look forward to your feedback.
