### PR TITLE
Subjects module added

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,8 @@ import { AppController } from './app.controller';
 import { UsersModule } from './users/users.module';
 import { TemplatesModule } from './templates/templates.module';
 import { EducationalProgramsModule } from './educational-programs/educational-programs.module';
+import { SubjectModule } from './subject/subject.module';
+import { PartialTemplatesModule } from './partial-templates/partial-templates.module';
 
 @Module({
   imports: [
@@ -12,6 +14,8 @@ import { EducationalProgramsModule } from './educational-programs/educational-pr
     UsersModule,
     EducationalProgramsModule,
     TemplatesModule,
+    PartialTemplatesModule,
+    SubjectModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/common/validation/custom-validation.pipe.ts
+++ b/src/common/validation/custom-validation.pipe.ts
@@ -21,3 +21,17 @@ export class CustomValidationPipe extends ValidationPipe {
         }
     }
 }
+
+export class validateForeignKeys {
+    private validations = []
+    constructor() { }
+    add(validation) {
+        this.validations.push(validation)
+    }
+    async validate(){
+        const res = await Promise.all(this.validations)
+        if (res.some(count => count === 0)) {
+            throw new BadRequestException('Relación no encontrada')
+        }
+    }
+}

--- a/src/common/validation/custom-validation.pipe.ts
+++ b/src/common/validation/custom-validation.pipe.ts
@@ -28,7 +28,7 @@ export class validateForeignKeys {
     add(validation) {
         this.validations.push(validation)
     }
-    async validate(){
+    async validate() {
         const res = await Promise.all(this.validations)
         if (res.some(count => count === 0)) {
             throw new BadRequestException('Relación no encontrada')

--- a/src/educational-programs/educational-programs.controller.ts
+++ b/src/educational-programs/educational-programs.controller.ts
@@ -19,7 +19,7 @@ export class EducationalProgramsController {
    */
   @Post()
   create(@Body() createEducationalProgramDto: CreateEducationalProgramDto) {
-    return this.educationalProgramsService.createProg({ ...createEducationalProgramDto});
+    return this.educationalProgramsService.createProg({ ...createEducationalProgramDto} as any);
   }
 
   /**

--- a/src/models/subject/create-subject.dto.ts
+++ b/src/models/subject/create-subject.dto.ts
@@ -1,0 +1,17 @@
+import { IsInt, IsNotEmpty, IsString } from "class-validator"
+
+export class CreateSubjectDto {
+    @IsNotEmpty({message: 'El programa educativo no puede estar vacío'})
+    @IsString({message: 'El programa educativo debe ser un texto'})
+    educationalProgramId: number
+    @IsInt({message: 'El total de horas debe ser un número entero'})
+    totalHours: number
+    @IsInt({message: 'Las horas semanales deben ser un número entero'})
+    weeklyHours: number
+    @IsNotEmpty({message: 'El periodo no puede estar vacío'})
+    @IsString({message: 'El periodo debe ser un texto'})
+    monthPeriod: string
+    @IsNotEmpty({message: 'El nombre de la materia no puede estar vacío'})
+    @IsString({message: 'El nombre de la materia debe ser un texto'})
+    subjectName: string
+}

--- a/src/models/subject/update-subject.dto.ts
+++ b/src/models/subject/update-subject.dto.ts
@@ -1,0 +1,9 @@
+import { PartialType } from "@nestjs/mapped-types"
+import { CreateSubjectDto } from "./create-subject.dto"
+
+export class UpdateSubjectDto extends PartialType(CreateSubjectDto) {
+    totalHours?: number
+    weeklyHours?: number
+    monthPeriod?: string
+    subjectName?: string
+}

--- a/src/partial-templates/partial-templates.service.ts
+++ b/src/partial-templates/partial-templates.service.ts
@@ -32,7 +32,7 @@ export class PartialTemplatesService {
     return this.prisma.partialTemplate.create({
       data: {
         ...createPartialTemplateDto,
-      },
+      } as any,
     });
   }
 

--- a/src/subject/subject.controller.spec.ts
+++ b/src/subject/subject.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubjectController } from './subject.controller';
+
+describe('SubjectController', () => {
+  let controller: SubjectController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SubjectController],
+    }).compile();
+
+    controller = module.get<SubjectController>(SubjectController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller('subject')
+export class SubjectController {}

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Put } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
 import { SubjectService } from './subject.service';
 import { CreateSubjectDto } from 'src/models/subject/create-subject.dto';
 import { UpdateSubjectDto } from 'src/models/subject/update-subject.dto';

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -1,4 +1,34 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Put } from '@nestjs/common';
+import { SubjectService } from './subject.service';
+import { CreateSubjectDto } from 'src/models/subject/create-subject.dto';
+import { UpdateSubjectDto } from 'src/models/subject/update-subject.dto';
 
 @Controller('subject')
-export class SubjectController {}
+export class SubjectController {
+    constructor(private readonly subjectService: SubjectService) {}
+
+    @Post()
+    create(@Body() createSubjectDto: CreateSubjectDto) {
+        return this.subjectService.create(createSubjectDto);
+    }
+
+    @Get()
+    findAll() {
+        return this.subjectService.findAll();
+    }
+
+    @Get(':id')
+    findOne(@Param('id', ParseIntPipe) id: number) {
+        return this.subjectService.findOne(id);
+    }
+
+    @Get('program/:id')
+    findByProgram(@Param('id', ParseIntPipe) id: number) {
+        return this.subjectService.findByProgram(id);
+    }
+
+    @Patch(':id')
+    update(@Param('id', ParseIntPipe) id: number, @Body() updateSubjectDto: UpdateSubjectDto) {
+        return this.subjectService.update(id, updateSubjectDto);
+    }
+}

--- a/src/subject/subject.controller.ts
+++ b/src/subject/subject.controller.ts
@@ -6,27 +6,47 @@ import { UpdateSubjectDto } from 'src/models/subject/update-subject.dto';
 @Controller('subject')
 export class SubjectController {
     constructor(private readonly subjectService: SubjectService) {}
-
+    /**
+     * Handles the post request to create a new subject
+     * @param createSubjectDto 
+     * @returns 
+     */
     @Post()
     create(@Body() createSubjectDto: CreateSubjectDto) {
         return this.subjectService.create(createSubjectDto);
     }
-
+    /**
+     * Handles the get request to get all subjects
+     * @returns 
+     */
     @Get()
     findAll() {
         return this.subjectService.findAll();
     }
-
+    /**
+     * Handles the get request to get a subject by id
+     * @param id 
+     * @returns 
+     */
     @Get(':id')
     findOne(@Param('id', ParseIntPipe) id: number) {
         return this.subjectService.findOne(id);
     }
-
+    /**
+     * Handles the get request to get all subjects by program id
+     * @param id 
+     * @returns 
+     */
     @Get('program/:id')
     findByProgram(@Param('id', ParseIntPipe) id: number) {
         return this.subjectService.findByProgram(id);
     }
-
+    /**
+     * Handles the patch request to update a subject
+     * @param id 
+     * @param updateSubjectDto 
+     * @returns 
+     */
     @Patch(':id')
     update(@Param('id', ParseIntPipe) id: number, @Body() updateSubjectDto: UpdateSubjectDto) {
         return this.subjectService.update(id, updateSubjectDto);

--- a/src/subject/subject.module.ts
+++ b/src/subject/subject.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SubjectService } from './subject.service';
+import { SubjectController } from './subject.controller';
+import { PrismaService } from 'src/prisma.service';
+import { validateForeignKeys } from 'src/common/validation/custom-validation.pipe';
+
+@Module({
+  providers: [SubjectService, PrismaService, validateForeignKeys],
+  controllers: [SubjectController]
+})
+export class SubjectModule {}

--- a/src/subject/subject.service.spec.ts
+++ b/src/subject/subject.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubjectService } from './subject.service';
+
+describe('SubjectService', () => {
+  let service: SubjectService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SubjectService],
+    }).compile();
+
+    service = module.get<SubjectService>(SubjectService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -4,7 +4,9 @@ import { validateForeignKeys } from "src/common/validation/custom-validation.pip
 import { CreateSubjectDto } from "src/models/subject/create-subject.dto";
 import { UpdateSubjectDto } from "src/models/subject/update-subject.dto";
 import { PrismaService } from "src/prisma.service";
-
+/**
+ * Interface to define the methods of the subjects service
+ */
 interface SubjectResult {
     create(createSubjectDto: CreateSubjectDto): Promise<{ message: string, data: Subject, error: string | null }>
     findByProgram(id: number): Promise<{ message: string, data: Subject[] | null, error: string | null }>
@@ -19,6 +21,11 @@ export class SubjectService implements SubjectResult {
         private readonly prisma: PrismaService,
         private readonly foreign: validateForeignKeys
     ) { }
+    /**
+     * Creates a new subject
+     * @param createSubjectDto data to create a new subject
+     * @returns object with the new subject, a message and an error if ocurred
+     */
     async create(createSubjectDto: CreateSubjectDto) {
         this.foreign.add(this.prisma.educationalPrograms.count({ where: { id: createSubjectDto.educationalProgramId } }))
         this.foreign.validate()
@@ -41,6 +48,11 @@ export class SubjectService implements SubjectResult {
             }
         }
     }
+    /**
+     * Returns all subjects of an educational program
+     * @param id the id of the educational program
+     * @returns object with the subjects, a message and an error if ocurred
+     */
     async findByProgram(id: number) {
         try {
             const subjects = await this.prisma.subject.findMany({
@@ -63,6 +75,11 @@ export class SubjectService implements SubjectResult {
             }
         }
     }
+    /**
+     * Returns a subject by its id
+     * @param id id of the subject
+     * @returns object with the subject, a message and an error if ocurred
+     */
     async findOne(id: number) {
         try {
             const subject = await this.prisma.subject.findFirst({
@@ -82,6 +99,10 @@ export class SubjectService implements SubjectResult {
             }
         }
     }
+    /**
+     * Returns all subjects
+     * @returns object with all subjects, a message and an error if ocurred
+     */
     async findAll() {
         try {
             const subjects = await this.prisma.subject.findMany({ orderBy: { educationalProgramId: 'asc', monthPeriod: 'asc', subjectName: 'asc' } });
@@ -99,6 +120,12 @@ export class SubjectService implements SubjectResult {
             }
         }
     }
+    /**
+     * Updates a subject by its id
+     * @param id id of the subject
+     * @param updateSubjectDto data to update the subject
+     * @returns object with the updated subject, a message and an error if ocurred
+     */
     async update(id: number, updateSubjectDto: UpdateSubjectDto) {
         try {
             this.findOne(id);

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -1,64 +1,126 @@
-import { HttpException, Injectable, NotFoundException } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { Subject } from "@prisma/client";
 import { validateForeignKeys } from "src/common/validation/custom-validation.pipe";
 import { CreateSubjectDto } from "src/models/subject/create-subject.dto";
 import { UpdateSubjectDto } from "src/models/subject/update-subject.dto";
 import { PrismaService } from "src/prisma.service";
 
-@Injectable()
-export class SubjectService {
-    constructor(private readonly prisma: PrismaService, private readonly foreign: validateForeignKeys) { }
-    async create(createSubjectDto: CreateSubjectDto): Promise<{ message: string }> {
+interface SubjectResult {
+    create(createSubjectDto: CreateSubjectDto): Promise<{ message: string, data: Subject, error: string | null }>
+    findByProgram(id: number): Promise<{ message: string, data: Subject[] | null, error: string | null }>
+    findOne(id: number): Promise<{ message: string, data: Subject | null, error: null | string }>
+    findAll(): Promise<{ message: string, data: Subject[], error: null | string }>
+    update(id: number, updateSubjectDto: UpdateSubjectDto): Promise<{ message: string, data: Subject, error: null | string }>
+}
 
+@Injectable()
+export class SubjectService implements SubjectResult {
+    constructor(
+        private readonly prisma: PrismaService,
+        private readonly foreign: validateForeignKeys
+    ) { }
+    async create(createSubjectDto: CreateSubjectDto) {
         this.foreign.add(this.prisma.educationalPrograms.count({ where: { id: createSubjectDto.educationalProgramId } }))
         this.foreign.validate()
-        const created = await this.prisma.subject.create({
-            data: {
-                ...createSubjectDto,
-            },
-        });
-        if (!created) throw new HttpException("Error al registrar materia", 500);
-        return {
-            message: "Registrado!"
-        };
-    }
-    async findByProgram(id: number): Promise<Subject[]> {
-        const subjects = await this.prisma.subject.findMany({
-            where: {
-                educationalProgramId: id
-            },
-            orderBy: { monthPeriod: 'asc', subjectName: 'asc' }
-        });
-        if (!subjects) throw new NotFoundException("No se encontraron materias");
-        return subjects;
-    }
-    async findOne(id: number): Promise<Subject> {
-        const subject = await this.prisma.subject.findUnique({
-            where: {
-                id
+        try {
+            const subject = await this.prisma.subject.create({
+                data: {
+                    ...createSubjectDto,
+                },
+            })
+            return {
+                data: subject,
+                error: null,
+                message: 'Registrado!'
             }
-        });
-        if (!subject) throw new NotFoundException("No se encontró la materia");
-        return subject;
-    }
-    async findAll(): Promise<Subject[]> {
-        const subjects = await this.prisma.subject.findMany({ orderBy: { educationalProgramId: 'asc', monthPeriod: 'asc', subjectName: 'asc' } });
-        if (!subjects) throw new NotFoundException("No se encontraron materias");
-        return subjects;
-    }
-    async update(id: number, updateSubjectDto: UpdateSubjectDto): Promise<{ message: string }> {
-        this.findOne(id);
-        const updated = await this.prisma.subject.update({
-            where: {
-                id
-            },
-            data: {
-                ...updateSubjectDto
+        } catch (error) {
+            return {
+                data: null,
+                error: 'Error de registro',
+                message: 'Error al registrar la materia'
             }
-        });
-        if (!updated) throw new HttpException("Error al actualizar materia", 500);
-        return {
-            message: "Actualizado!"
-        };
+        }
+    }
+    async findByProgram(id: number) {
+        try {
+            const subjects = await this.prisma.subject.findMany({
+                where: {
+                    educationalProgramId: id
+                },
+                orderBy: { monthPeriod: 'asc', subjectName: 'asc' }
+            });
+            if (!subjects) throw new NotFoundException("No se encontraron materias");
+            return {
+                message: 'Materias econtradas',
+                data: subjects,
+                error: null
+            }
+        } catch (error) {
+            return {
+                data: null,
+                error: 'Error al buscar materias',
+                message: 'Error al buscar las materias en el sistema'
+            }
+        }
+    }
+    async findOne(id: number) {
+        try {
+            const subject = await this.prisma.subject.findFirst({
+                where: { id }
+            })
+            const message = subject ? 'Materia econtrada' : 'Materia no econtrada'
+            return {
+                data: subject,
+                error: null,
+                message
+            }
+        } catch (error) {
+            return {
+                data: null,
+                error: 'Error de búsqueda',
+                message: 'Error al buscar la materia'
+            }
+        }
+    }
+    async findAll() {
+        try {
+            const subjects = await this.prisma.subject.findMany({ orderBy: { educationalProgramId: 'asc', monthPeriod: 'asc', subjectName: 'asc' } });
+            const message = subjects ? 'Todas las materias de todas las carreras' : 'No se encontraron materias'
+            return {
+                data: subjects,
+                message,
+                error: null
+            }
+        } catch (error) {
+            return {
+                data: null,
+                error: 'Error de búsqueda',
+                message: 'Error al obtener las materias'
+            }
+        }
+    }
+    async update(id: number, updateSubjectDto: UpdateSubjectDto) {
+        try {
+            this.findOne(id);
+            const updated = await this.prisma.subject.update({
+                where: {
+                    id
+                },
+                data: {
+                    ...updateSubjectDto
+                }
+            });
+            return {
+                data: updated,
+                message: "Actualizado!",
+                error: null
+            };
+        } catch (error) {
+            return {
+                data: null,
+                error: 'Error de actualización',
+                message: 'Error al actualizar el registro'
+            }
+        }
     }
 }

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -1,20 +1,64 @@
-import { Injectable } from "@nestjs/common";
+import { HttpException, Injectable, NotFoundException } from "@nestjs/common";
 import { Subject } from "@prisma/client";
 import { validateForeignKeys } from "src/common/validation/custom-validation.pipe";
 import { CreateSubjectDto } from "src/models/subject/create-subject.dto";
+import { UpdateSubjectDto } from "src/models/subject/update-subject.dto";
 import { PrismaService } from "src/prisma.service";
 
 @Injectable()
 export class SubjectService {
     constructor(private readonly prisma: PrismaService, private readonly foreign: validateForeignKeys) { }
-    async create(createSubjectDto: CreateSubjectDto): Promise<Subject> {
+    async create(createSubjectDto: CreateSubjectDto): Promise<{ message: string }> {
 
-        this.foreign.add(this.prisma.educationalPrograms.count({where: {id: createSubjectDto.educationalProgramId}}))
+        this.foreign.add(this.prisma.educationalPrograms.count({ where: { id: createSubjectDto.educationalProgramId } }))
         this.foreign.validate()
-        return await this.prisma.subject.create({
+        const created = await this.prisma.subject.create({
             data: {
                 ...createSubjectDto,
             },
         });
+        if (!created) throw new HttpException("Error al registrar materia", 500);
+        return {
+            message: "Registrado!"
+        };
+    }
+    async findByProgram(id: number): Promise<Subject[]> {
+        const subjects = await this.prisma.subject.findMany({
+            where: {
+                educationalProgramId: id
+            },
+            orderBy: { monthPeriod: 'asc', subjectName: 'asc' }
+        });
+        if (!subjects) throw new NotFoundException("No se encontraron materias");
+        return subjects;
+    }
+    async findOne(id: number): Promise<Subject> {
+        const subject = await this.prisma.subject.findUnique({
+            where: {
+                id
+            }
+        });
+        if (!subject) throw new NotFoundException("No se encontró la materia");
+        return subject;
+    }
+    async findAll(): Promise<Subject[]> {
+        const subjects = await this.prisma.subject.findMany({ orderBy: { educationalProgramId: 'asc', monthPeriod: 'asc', subjectName: 'asc' } });
+        if (!subjects) throw new NotFoundException("No se encontraron materias");
+        return subjects;
+    }
+    async update(id: number, updateSubjectDto: UpdateSubjectDto): Promise<{ message: string }> {
+        this.findOne(id);
+        const updated = await this.prisma.subject.update({
+            where: {
+                id
+            },
+            data: {
+                ...updateSubjectDto
+            }
+        });
+        if (!updated) throw new HttpException("Error al actualizar materia", 500);
+        return {
+            message: "Actualizado!"
+        };
     }
 }

--- a/src/subject/subject.service.ts
+++ b/src/subject/subject.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from "@nestjs/common";
+import { Subject } from "@prisma/client";
+import { validateForeignKeys } from "src/common/validation/custom-validation.pipe";
+import { CreateSubjectDto } from "src/models/subject/create-subject.dto";
+import { PrismaService } from "src/prisma.service";
+
+@Injectable()
+export class SubjectService {
+    constructor(private readonly prisma: PrismaService, private readonly foreign: validateForeignKeys) { }
+    async create(createSubjectDto: CreateSubjectDto): Promise<Subject> {
+
+        this.foreign.add(this.prisma.educationalPrograms.count({where: {id: createSubjectDto.educationalProgramId}}))
+        this.foreign.validate()
+        return await this.prisma.subject.create({
+            data: {
+                ...createSubjectDto,
+            },
+        });
+    }
+}


### PR DESCRIPTION
## Overview
This pull requests add new `SubjectModule` module for crud operations 

## Changes
- **Service:** Added `SubjectService` to use the prisma service as a provider and perform the crud operations.
- **Controller:** Added `SubjectController` to handle http methods and sub routes for the subject's route.
- **DTOs:** Added `CreateSubjectDto` and `UpdateSubjectDto` to bring the datatypes for the service and perform some validations.
- **Documentation:** JSDoc was added to explain how the code works.

## Details
1. **SubjectService**
   - `create()`: Creates a new subject.
   - `findByProgram()`: Returns all subjects of an educational.
   - `findOne()`: Returns a subject by its id.
   - `findAll()`: Returns all subjects.
   - `update()`: Updates a subject by its id

2. **SubjectController**
   - `create()`: Handles the post request to create a new subject.
   - `findAll()`: Handles the get request to get all subjects.
   - `findOne()`: Handles the get request to get a subject by id.
   - `findByProgram()`: Handles the get request to get all subjects by program id.
   - `update()`: Handles the patch request to update a subject.

5. **JSDoc Documentation**
   - Added detailed documentation to all methods and classes in the `SubjectController` and `SubjectService` for better understanding and maintenance.

## Related Issues
if is related to an issue or can close an issue
- Closes #8 

## Notes
- To perform test you may need to add the correct data in the tables.

Thank you for reviewing this pull request. I look forward to your feedback.
